### PR TITLE
feat: unresolved commits count label

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -1873,7 +1873,10 @@ async def handle_pull_request_opened(payload: dict, token: str, env=None) -> Non
         await _post_or_update_leaderboard(owner, repo, pr_number, author_login, token, env)
 
     # Check for unresolved review conversations
-    await check_unresolved_conversations(payload, token)
+    try:
+        await check_unresolved_conversations(payload, token)
+    except Exception as exc:
+        console.error(f"[BLT] check_unresolved_conversations failed (best-effort, ignored): {exc}")
 
 
 async def handle_pull_request_closed(payload: dict, token: str, env=None) -> None:
@@ -1983,10 +1986,16 @@ async def check_unresolved_conversations(payload, token):
         return
 
     result = json.loads(await resp.text())
-    threads = (
+    pull_request = (
         result.get("data", {})
         .get("repository", {})
-        .get("pullRequest", {})
+        .get("pullRequest")
+    )
+    if result.get("errors") or pull_request is None:
+        console.error(f"[BLT] GraphQL reviewThreads query returned errors: {result.get('errors')}")
+        return
+    threads = (
+        pull_request
         .get("reviewThreads", {})
         .get("nodes", [])
     )

--- a/test_worker.py
+++ b/test_worker.py
@@ -976,7 +976,8 @@ class TestHandlePullRequestOpenedLeaderboard(unittest.TestCase):
             with patch.object(_worker, "_post_or_update_leaderboard", new=_mock_leaderboard):
                 with patch.object(_worker, "_check_and_close_excess_prs", new=_mock_close):
                     with patch.object(_worker, "create_comment", new=AsyncMock(side_effect=lambda o, r, n, b, t: comment_calls.append(b))):
-                        await _worker.handle_pull_request_opened(payload, "tok")
+                        with patch.object(_worker, "check_unresolved_conversations", new=AsyncMock(return_value=None)):
+                            await _worker.handle_pull_request_opened(payload, "tok")
         _run(_inner())
 
     def test_posts_leaderboard_on_pr_open(self):
@@ -1016,7 +1017,8 @@ class TestHandlePullRequestOpenedLeaderboard(unittest.TestCase):
             with patch.object(_worker, "_post_or_update_leaderboard", new=_mock_leaderboard):
                 with patch.object(_worker, "_check_and_close_excess_prs", new=_mock_close):
                     with patch.object(_worker, "create_comment", new=AsyncMock(side_effect=lambda o, r, n, b, t: comments.append(b))):
-                        await _worker.handle_pull_request_opened(payload, "tok")
+                        with patch.object(_worker, "check_unresolved_conversations", new=AsyncMock(return_value=None)):
+                            await _worker.handle_pull_request_opened(payload, "tok")
         _run(_inner())
         
         # Should check for excess PRs
@@ -1616,8 +1618,6 @@ class TestCheckUnresolvedConversations(unittest.TestCase):
                     await _worker.check_unresolved_conversations(self._payload(), "tok")
 
         _run(_inner())
-        # _ensure_label_exists should have been called with red colour
-        ensure_calls = [c for c in api_calls if len(c) >= 2 and "labels/" in str(c[1]) and c[0] == "GET"]
         add_label_calls = [c for c in api_calls if c[0] == "POST" and "/issues/7/labels" in c[1]]
         self.assertTrue(len(add_label_calls) >= 1, f"Expected POST to add label, got {api_calls}")
         # Should use label name with count 1


### PR DESCRIPTION
### feat: unresolved conversations count label

Adds a dynamic unresolved-conversations: N label to PRs that tracks the number of unresolved review threads. The label is red when there are unresolved threads and green when all are resolved.

Uses the GitHub GraphQL API to query `reviewThreads.isResolved` since the REST API doesn't expose resolution status.

Triggered on: 
`pull_request_review`, `pull_request_review_comment`, `pull_request_review_thread`

Note: The GitHub App must be subscribed to `pull_request_review_comment` and `pull_request_review_thread` events in Settings → Permissions & events for this to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests now automatically receive labels displaying the count of unresolved review conversations
  * Labels dynamically update as reviews are submitted, comments are added, and conversation threads change
  * Color-coded labels indicate status to help you quickly distinguish active versus resolved conversations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->