### PR TITLE
Fix/webhook fail closed health guard

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -4360,7 +4360,7 @@ async def handle_webhook(request, env) -> Response:
     item_number = issue_number or pr_number or ""
 
     signature = request.headers.get("X-Hub-Signature-256") or ""
-    secret = getattr(env, "WEBHOOK_SECRET", "")
+    secret = (getattr(env, "WEBHOOK_SECRET", "") or "").strip()
     if not secret:
         console.error(
             "[BLT][webhook] "
@@ -4574,9 +4574,9 @@ def _webhook_security_status(env) -> dict:
     Webhook processing is secure-ready only when all auth-related secrets are
     present: ``APP_ID``, ``PRIVATE_KEY``, and ``WEBHOOK_SECRET``.
     """
-    app_id_set = bool(getattr(env, "APP_ID", "")) if env else False
-    private_key_set = bool(getattr(env, "PRIVATE_KEY", "")) if env else False
-    webhook_secret_set = bool(getattr(env, "WEBHOOK_SECRET", "")) if env else False
+    app_id_set = bool((getattr(env, "APP_ID", "") or "").strip()) if env else False
+    private_key_set = bool((getattr(env, "PRIVATE_KEY", "") or "").strip()) if env else False
+    webhook_secret_set = bool((getattr(env, "WEBHOOK_SECRET", "") or "").strip()) if env else False
 
     missing = []
     if not app_id_set:

--- a/test_worker.py
+++ b/test_worker.py
@@ -2869,6 +2869,7 @@ class TestWebhookSecurityGuards(unittest.TestCase):
     """Webhook auth fail-closed and health guard tests."""
 
     def _make_webhook_request(self, body="{}", headers=None):
+        """Build a minimal webhook request object for worker route tests."""
         req_headers = _HeadersStub(headers or {})
         return types.SimpleNamespace(
             method="POST",
@@ -2878,6 +2879,7 @@ class TestWebhookSecurityGuards(unittest.TestCase):
         )
 
     def _make_health_request(self):
+        """Build a minimal GET /health request object."""
         return types.SimpleNamespace(
             method="GET",
             url="https://example.com/health",
@@ -2888,6 +2890,7 @@ class TestWebhookSecurityGuards(unittest.TestCase):
     def test_webhook_rejects_when_secret_missing(self):
         """Webhook endpoint should fail closed when WEBHOOK_SECRET is not configured."""
         async def _inner():
+            """Execute missing-secret webhook rejection assertions."""
             req = self._make_webhook_request(
                 body=json.dumps({"action": "opened", "repository": {"full_name": "OWASP-BLT/BLT-GitHub-App"}}),
                 headers={
@@ -2909,6 +2912,7 @@ class TestWebhookSecurityGuards(unittest.TestCase):
     def test_health_reports_degraded_when_webhook_secret_missing(self):
         """/health should expose degraded status when webhook security config is incomplete."""
         async def _inner():
+            """Execute health assertions for missing webhook secret."""
             req = self._make_health_request()
             env = types.SimpleNamespace(APP_ID="123", PRIVATE_KEY="pem")
 
@@ -2926,8 +2930,9 @@ class TestWebhookSecurityGuards(unittest.TestCase):
         _run(_inner())
 
     def test_health_reports_ok_when_webhook_security_ready(self):
-        """/health should report ok when webhook security config is fully present."""
+        """/health should report ok with real secret and degraded for whitespace-only secret."""
         async def _inner():
+            """Execute ready and whitespace-secret health assertions."""
             req = self._make_health_request()
             env = types.SimpleNamespace(APP_ID="123", PRIVATE_KEY="pem", WEBHOOK_SECRET="secret")
 
@@ -2938,6 +2943,51 @@ class TestWebhookSecurityGuards(unittest.TestCase):
             payload = json.loads(resp.body)
             self.assertEqual(payload.get("status"), "ok")
             self.assertTrue(payload.get("checks", {}).get("webhook_security", {}).get("ready"))
+
+            blank_env = types.SimpleNamespace(APP_ID="123", PRIVATE_KEY="pem", WEBHOOK_SECRET="   ")
+            with patch.object(_worker, "console", new=types.SimpleNamespace(error=lambda x: None, log=lambda x: None)):
+                blank_resp = await _worker.on_fetch(req, blank_env)
+
+            self.assertEqual(blank_resp.status, 200)
+            blank_payload = json.loads(blank_resp.body)
+            self.assertEqual(blank_payload.get("status"), "degraded")
+            self.assertFalse(blank_payload.get("checks", {}).get("webhook_security", {}).get("ready"))
+
+        _run(_inner())
+
+    def test_health_reports_degraded_when_webhook_secret_blank(self):
+        """Blank WEBHOOK_SECRET should be treated as missing and emit structured rejection logs."""
+        async def _inner():
+            """Execute blank-secret health and webhook structured-log assertions."""
+            req = self._make_health_request()
+            env = types.SimpleNamespace(APP_ID="123", PRIVATE_KEY="pem", WEBHOOK_SECRET="  ")
+            logs = []
+
+            console_stub = types.SimpleNamespace(
+                error=lambda x: logs.append(str(x)),
+                log=lambda x: logs.append(str(x)),
+            )
+            with patch.object(_worker, "console", new=console_stub):
+                resp = await _worker.on_fetch(req, env)
+
+            self.assertEqual(resp.status, 200)
+            payload = json.loads(resp.body)
+            self.assertEqual(payload.get("status"), "degraded")
+            checks = payload.get("checks", {}).get("webhook_security", {}).get("checks", {})
+            self.assertFalse(checks.get("webhook_secret_configured"))
+
+            webhook_req = self._make_webhook_request(
+                body=json.dumps({"action": "opened", "repository": {"full_name": "OWASP-BLT/BLT-GitHub-App"}}),
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-blank-secret",
+                },
+            )
+            with patch.object(_worker, "console", new=console_stub):
+                webhook_resp = await _worker.on_fetch(webhook_req, env)
+
+            self.assertEqual(webhook_resp.status, 503)
+            self.assertTrue(any("rejected_missing_webhook_secret" in msg for msg in logs))
 
         _run(_inner())
 


### PR DESCRIPTION
closes #76 

### Problem
Webhook auth previously failed *open*. If `WEBHOOK_SECRET` was missing, signature validation was skipped entirely.

### What Changed
* **Fail-Closed:** Returns `503` immediately if `WEBHOOK_SECRET` is missing, blocking unauthenticated traffic.
* **Health Guard:** `GET /health` now surfaces webhook readiness. Returns `status: degraded` if `APP_ID`, `PRIVATE_KEY`, or `WEBHOOK_SECRET` are missing.
* **Observability:** Added structured error logging (`status=rejected_missing_webhook_secret`).

**Safety:** Only tightens security. No behavior is relaxed. `/health` remains backward-compatible.

**Tests:** Added unit tests for 503 rejections and new health states. All 336 tests passing. ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added webhook security validation to check required configuration before processing webhooks.
  * Health endpoint now includes webhook security readiness status to reflect current system state.
  * Webhooks are rejected with explicit error codes (503) when required secrets are missing.

* **Tests**
  * Added comprehensive tests for webhook security validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->