### PR TITLE
fix(leaderboard): enforce live org reconciliation to prevent drift

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -1010,11 +1010,21 @@ async def _track_pr_opened_in_d1(payload: dict, env) -> None:
     await _ensure_leaderboard_schema(db)
     existing = await _d1_first(
         db,
-        "SELECT state FROM leaderboard_pr_state WHERE org = ? AND repo = ? AND pr_number = ?",
+        "SELECT author_login, state, merged, closed_at FROM leaderboard_pr_state WHERE org = ? AND repo = ? AND pr_number = ?",
         (org, repo, pr_number),
     )
     if not existing or existing.get("state") != "open":
         await _d1_inc_open_pr(db, org, author_login, 1)
+
+    # If a previously closed PR is observed as opened again, reverse the old
+    # monthly close/merge credit for the original author to keep totals stable.
+    if existing and existing.get("state") == "closed":
+        existing_author = existing.get("author_login") or author_login
+        prev_merged = int(existing.get("merged") or 0)
+        prev_closed_at = int(existing.get("closed_at") or 0)
+        prev_mk = _month_key(prev_closed_at) if prev_closed_at else _month_key()
+        prev_field = "merged_prs" if prev_merged else "closed_prs"
+        await _d1_inc_monthly(db, org, prev_mk, existing_author, prev_field, -1)
 
     now = int(time.time())
     await _d1_run(

--- a/test_worker.py
+++ b/test_worker.py
@@ -1862,6 +1862,40 @@ class TestTrackingOperations(unittest.TestCase):
         # Should have called prepare multiple times (ensure schema, check existing, insert)
         self.assertGreater(mock_db.prepare.call_count, 0)
 
+    async def _test_track_pr_opened_reverses_previous_closed_credit(self):
+        """Opening a previously closed PR should reverse prior monthly credit using stored author."""
+        payload = {
+            "repository": {"owner": {"login": "OWASP-BLT"}, "name": "test-repo"},
+            "pull_request": {
+                "number": 42,
+                "user": {"login": "alice", "type": "User"},
+            },
+        }
+        env = types.SimpleNamespace(LEADERBOARD_DB=object())
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(_worker, "_ensure_leaderboard_schema", new=AsyncMock()))
+            stack.enter_context(
+                patch.object(
+                    _worker,
+                    "_d1_first",
+                    new=AsyncMock(return_value={"author_login": "bob", "state": "closed", "merged": 1, "closed_at": 1709596800}),
+                )
+            )
+            monthly_mock = stack.enter_context(patch.object(_worker, "_d1_inc_monthly", new=AsyncMock()))
+            open_mock = stack.enter_context(patch.object(_worker, "_d1_inc_open_pr", new=AsyncMock()))
+            stack.enter_context(patch.object(_worker, "_d1_run", new=AsyncMock()))
+            await _worker._track_pr_opened_in_d1(payload, env)
+
+        self.assertEqual(open_mock.await_count, 1)
+        self.assertEqual(open_mock.await_args.args[2], "alice")
+        self.assertEqual(open_mock.await_args.args[3], 1)
+        self.assertEqual(monthly_mock.await_count, 1)
+        monthly_args = monthly_mock.await_args.args
+        self.assertEqual(monthly_args[3], "bob")
+        self.assertEqual(monthly_args[4], "merged_prs")
+        self.assertEqual(monthly_args[5], -1)
+
     async def _test_track_comment(self):
         """Test comment tracking via D1"""
         mock_db = MagicMock()
@@ -2003,6 +2037,9 @@ class TestTrackingOperations(unittest.TestCase):
 
     def test_track_pr_opened(self):
         _run(self._test_track_pr_opened())
+
+    def test_track_pr_opened_reverses_previous_closed_credit(self):
+        _run(self._test_track_pr_opened_reverses_previous_closed_credit())
 
     def test_track_comment(self):
         _run(self._test_track_comment())


### PR DESCRIPTION
closes #78 

## Fix leaderboard drift with live reconciliation

### What this fixes
- Removes one-time backfill gate dependency that caused permanent drift after missed webhook events.
- Ensures org leaderboard data is reconciled from live GitHub state on leaderboard fetch.
- Prevents stale historical/backfill gate artifacts from blocking future correctness.

### Key changes
- Added org-wide live reconciliation flow.
- Updated leaderboard fetch path to run reconciliation before rendering.
- Hardened PR close state transitions to reverse prior credit when event state changes.
- Added regression tests.

### Validation
- Test suite: 346 passed
- Live OWASP-BLT verification for aryanghai12:
  - Open PRs: 5
  - Merged this month: 5
  - Closed unmerged this month: 1
  
  
<img width="411" height="157" alt="image" src="https://github.com/user-attachments/assets/ee438855-a0c7-43d9-b165-8ef537d9fb9c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PR state transitions now reverse prior closed credits and apply monthly adjustments.
  * Improved PR author detection for accurate credit assignment.
  * Reconciliation is scoped to the current month; failures are logged and non-blocking.

* **New Features**
  * Org leaderboards can be rebuilt from live GitHub state with per-org controls, concurrency handling, and cleanup of stale backfill.
  * Clear fallback messaging when live reconciliation is unavailable or capped.

* **Tests**
  * Added tests for PR credit reversal, org reconciliation flows, paging caps, and scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->