### PR TITLE
security(cors): default JSON responses to no CORS; allow wildcard only for GET /health

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -5902,14 +5902,17 @@ async def _handle_add_mentor(request, env) -> "Response":
 # ---------------------------------------------------------------------------
 
 
-def _json(data, status: int = 200) -> Response:
+def _json(data, status: int = 200, allow_cors: bool = False) -> Response:
+    headers = {
+        "Content-Type": "application/json",
+    }
+    if allow_cors:
+        headers["Access-Control-Allow-Origin"] = "*"
+    
     return Response.new(
         json.dumps(data),
         status=status,
-        headers=Headers.new({
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
-        }.items()),
+        headers=Headers.new(headers.items()),
     )
 
 
@@ -5988,7 +5991,8 @@ async def on_fetch(request, env) -> Response:
                 "checks": {
                     "webhook_security": webhook_security,
                 },
-            }
+            },
+            allow_cors=True,
         )
 
     if method == "POST" and path == "/api/mentors":

--- a/test_worker.py
+++ b/test_worker.py
@@ -5827,6 +5827,84 @@ class TestOnFetchHomepage(unittest.TestCase):
         _run(_inner())
 
 
+class TestCorsPolicyOnFetch(unittest.TestCase):
+    """Minimal regression tests for PR-1 CORS policy on JSON routes."""
+
+    def _make_request(self, method="GET", path="/", body=None, headers=None):
+        req_headers = _HeadersStub(headers or {})
+        if isinstance(body, str):
+            body_text = body
+        elif body is None:
+            body_text = ""
+        else:
+            body_text = json.dumps(body)
+        return types.SimpleNamespace(
+            method=method,
+            url=f"https://example.com{path}",
+            headers=req_headers,
+            text=AsyncMock(return_value=body_text),
+        )
+
+    def test_health_includes_wildcard_cors_header(self):
+        async def _inner():
+            req = self._make_request(method="GET", path="/health")
+            env = types.SimpleNamespace(APP_ID="123", PRIVATE_KEY="pem", WEBHOOK_SECRET="secret")
+
+            with patch.object(_worker, "console", new=types.SimpleNamespace(error=lambda x: None, log=lambda x: None)):
+                resp = await _worker.on_fetch(req, env)
+
+            self.assertEqual(resp.status, 200)
+            self.assertEqual(resp.headers.get("Access-Control-Allow-Origin"), "*")
+
+        _run(_inner())
+
+    def test_api_mentors_success_has_no_cors_header(self):
+        async def _inner():
+            req = self._make_request(
+                method="POST",
+                path="/api/mentors",
+                body={"name": "Jane", "github_username": "jane"},
+            )
+            env = types.SimpleNamespace()
+            with patch.object(_worker, "_handle_add_mentor", new=AsyncMock(return_value=_worker._json({"ok": True}, 201))):
+                resp = await _worker.on_fetch(req, env)
+
+            self.assertEqual(resp.status, 201)
+            self.assertIsNone(resp.headers.get("Access-Control-Allow-Origin"))
+
+        _run(_inner())
+
+    def test_webhook_response_has_no_cors_header(self):
+        async def _inner():
+            req = self._make_request(method="POST", path="/api/github/webhooks", body={"action": "opened"})
+            env = types.SimpleNamespace()
+            with patch.object(_worker, "handle_webhook", new=AsyncMock(return_value=_worker._json({"ok": True}, 200))):
+                resp = await _worker.on_fetch(req, env)
+
+            self.assertEqual(resp.status, 200)
+            self.assertIsNone(resp.headers.get("Access-Control-Allow-Origin"))
+
+        _run(_inner())
+
+    def test_admin_reset_unauthorized_has_no_cors_header(self):
+        async def _inner():
+            req = self._make_request(
+                method="POST",
+                path="/admin/reset-leaderboard-month",
+                body={"org": "OWASP-BLT", "month_key": "2026-03"},
+                headers={"Authorization": "Bearer wrong-secret"},
+            )
+            env = types.SimpleNamespace(ADMIN_SECRET="test-secret", LEADERBOARD_DB=MagicMock())
+
+            with patch.object(_worker, "console", new=types.SimpleNamespace(error=lambda x: None, log=lambda x: None)):
+                resp = await _worker.on_fetch(req, env)
+
+            self.assertEqual(resp.status, 401)
+            self.assertIsNone(resp.headers.get("Access-Control-Allow-Origin"))
+
+        _run(_inner())
+
+
 class TestHandleAddMentor(unittest.TestCase):
     """POST /api/mentors — inserts a new mentor into D1."""
 


### PR DESCRIPTION

This PR hardens CORS behavior for JSON responses by switching from permissive default to explicit opt-in.

### What was wrong
- The JSON response helper in worker.py always sent:
  - `Access-Control-Allow-Origin: *`
- Because all JSON routes used this helper, write endpoints also exposed wildcard CORS (including `/api/mentors`, webhook, and admin reset routes).

### What changed
1. Updated JSON helper to default to no CORS:
- worker.py
- `def _json(data, status=200, allow_cors=False)`
- Adds `Access-Control-Allow-Origin: *` only when `allow_cors=True`

2. Explicitly allowed CORS only for read-only health endpoint:
- worker.py
- `GET /health` now calls `_json(..., allow_cors=True)`

3. Added regression tests for PR-1 CORS policy:
- test_worker.py
- Verifies:
  - `/health` includes wildcard CORS
  - `/api/mentors` response has no CORS header
  - `/api/github/webhooks` response has no CORS header
  - unauthorized admin reset response has no CORS header

### Why this fixes it
- Write endpoints no longer advertise permissive cross-origin access by default.
- CORS exposure is now explicit and limited to the intended public status endpoint.
- Regression tests lock this behavior to prevent future accidental reintroduction.

### Validation
- Targeted CORS tests passed.
- Full test_worker.py suite passed (`376 passed`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled CORS support for `/health` and `/api/mentors` endpoints.

* **Tests**
  * Added CORS header validation tests for health checks and API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->