### PR TITLE
fix: add mentor as GitHub assignee in _assign_mentor_to_issue

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -3262,6 +3262,14 @@ async def _assign_mentor_to_issue(
         {"labels": [MENTOR_ASSIGNED_LABEL]},
     )
 
+    # Step 5: Add the mentor as a GitHub assignee.
+    await github_api(
+        "POST",
+        f"/repos/{owner}/{repo}/issues/{issue_number}/assignees",
+        token,
+        {"assignees": [mentor_username]},
+    )
+
     specialties_info = ""
     if mentor.get("specialties"):
         specialties_info = f" (specialties: {', '.join(mentor['specialties'])})"

--- a/src/worker.py
+++ b/src/worker.py
@@ -3262,13 +3262,21 @@ async def _assign_mentor_to_issue(
         {"labels": [MENTOR_ASSIGNED_LABEL]},
     )
 
-    # Step 5: Add the mentor as a GitHub assignee.
-    await github_api(
+    # Step 5: Add the mentor as a GitHub assignee (best-effort).
+    assignee_resp = await github_api(
         "POST",
         f"/repos/{owner}/{repo}/issues/{issue_number}/assignees",
         token,
         {"assignees": [mentor_username]},
     )
+    assignee_status = getattr(assignee_resp, "status", None)
+    if assignee_status not in (200, 201):
+        console.error(
+            f"[MentorPool] Failed to add @{mentor_username} as GitHub assignee "
+            f"for {owner}/{repo}#{issue_number} (status={assignee_status}). "
+            "Mentor lacks repo collaborator access or the token is insufficient. "
+            "Label and comment were still applied."
+        )
 
     specialties_info = ""
     if mentor.get("specialties"):


### PR DESCRIPTION
## Summary
The `POST /assignees` API call was missing from `_assign_mentor_to_issue`. The mentor was announced in a comment and the `mentor-assigned` label was applied, but the GitHub assignee was never set.

## Root Cause
Step 5 in the docstring explicitly says "Add the mentor as a GitHub assignee" but the corresponding `POST /repos/{owner}/{repo}/issues/{number}/assignees` call was never implemented.

## Fix
Added the missing `github_api` call after the label is applied. The bot runs with GitHub App credentials which have the required permissions to assign users.

## Verified
Manually confirmed via `/mentor` command: `mentor-assigned` label was applied and comment posted, but Assignees panel showed "No one assigned".

Fixes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mentor assignment workflow now automatically adds selected mentors as issue assignees to streamline assignments.
* **Bug Fixes / Reliability**
  * Assignment is best-effort: failures are logged (e.g., insufficient access) but do not block follow-up actions like welcome comments or recording the assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->