### PR TITLE
 paginate open issues in _check_stale_assignments

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -6247,7 +6247,8 @@ async def _check_stale_assignments(owner: str, repo: str, token: str):
                 break
             issues.extend(page_issues)
             link_header = issues_resp.headers.get("Link") or ""
-            if 'rel="next"' not in link_header or len(page_issues) < per_page:
+            has_next = 'rel="next"' in link_header if link_header else len(page_issues) == per_page
+            if not has_next:
                 break
             page += 1
         if page > max_pages:

--- a/src/worker.py
+++ b/src/worker.py
@@ -6227,18 +6227,34 @@ async def scheduled(event, env):
 async def _check_stale_assignments(owner: str, repo: str, token: str):
     """Check a repository for stale issue assignments and unassign them."""
     try:
-        # Fetch open issues with assignees
-        issues_resp = await github_api(
-            "GET",
-            f"/repos/{owner}/{repo}/issues?state=open&per_page=100",
-            token
-        )
-        
-        if issues_resp.status != 200:
-            return
-        
-        issues = json.loads(await issues_resp.text())
-        
+        # Fetch all open issues across pages so repos with >100 open
+        # issues do not silently miss stale assignments.
+        issues: list = []
+        page = 1
+        per_page = 100
+        max_pages = 20
+        while page <= max_pages:
+            issues_resp = await github_api(
+                "GET",
+                f"/repos/{owner}/{repo}/issues?state=open&per_page={per_page}&page={page}",
+                token,
+            )
+            if issues_resp.status == 403:
+                console.warn(f"[CRON] GitHub rate limit hit while fetching issues for {owner}/{repo}; stopping pagination")
+                break
+            if issues_resp.status != 200:
+                return
+            page_issues = json.loads(await issues_resp.text())
+            if not isinstance(page_issues, list) or not page_issues:
+                break
+            issues.extend(page_issues)
+            link_header = issues_resp.headers.get("Link") or ""
+            if 'rel="next"' not in link_header or len(page_issues) < per_page:
+                break
+            page += 1
+        if page > max_pages:
+            console.warn(f"[CRON] Stale-assignment pagination capped at {max_pages} pages for {owner}/{repo}")
+
         # Filter issues that have assignees and are not pull requests
         assigned_issues = [
             issue for issue in issues

--- a/src/worker.py
+++ b/src/worker.py
@@ -6227,8 +6227,6 @@ async def scheduled(event, env):
 async def _check_stale_assignments(owner: str, repo: str, token: str):
     """Check a repository for stale issue assignments and unassign them."""
     try:
-        # Fetch all open issues across pages so repos with >100 open
-        # issues do not silently miss stale assignments.
         issues: list = []
         page = 1
         per_page = 100


### PR DESCRIPTION
The stale assignment cron was fetching open issues with a single request capped at per_page=100. Repositories with more than 100 open issues would silently skip all assignments beyond the first page, leaving expired assignments uncleaned indefinitely.

Changes:
- Replace the single API call with a paginated loop (max 20 pages, 2000 issues) using the same Link-header + page-size approach used elsewhere in the codebase
- Break gracefully on HTTP 403 (rate limit) with a console warning so the cron job degrades cleanly rather than crashing
- Use the Link response header as the primary pagination signal; fall back to the page-size comparison when the header is absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stale-assignment checks now scan all open issues across paginated results (multi-page aggregation, capped to prevent runaway requests).
  * Pagination now respects API signals and stops cleanly when no more pages are available.
  * Improved handling of API rate limits with logging and graceful termination.
  * Non-success API responses cause an immediate stop to avoid partial processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->