### PR TITLE
fix: backfill referred_by data for mentors on startup (closes #52)

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -704,6 +704,32 @@ async def _ensure_leaderboard_schema(db) -> None:
     await _populate_mentors_table(db)
 
 
+async def _backfill_referred_by(db) -> None:
+    """
+    Idempotent one-time backfill of referred_by data for mentors.
+    Runs automatically on every worker startup via on_fetch.
+    Only updates rows where referred_by is NULL or empty — safe to run repeatedly.
+    Closes: https://github.com/OWASP-BLT/BLT-Pool/issues/52
+    """
+    REFERRAL_DATA = [
+        ("ramansh18", "ojaswa072"),
+        ("gitsofaryan", "kunal241207"),
+        ("RudraBhaskar9439", "kunal241207"),
+        ("Mohammedfaiyaz29", "kunal241207"),
+        ("sarafarajnasardi", "swaparup36"),
+    ]
+    for github_username, referred_by in REFERRAL_DATA:
+        try:
+            stmt = db.prepare(
+                "UPDATE mentors SET referred_by = ? "
+                "WHERE lower(github_username) = lower(?) "
+                "AND (referred_by IS NULL OR referred_by = '')"
+            )
+            await stmt.bind(referred_by, github_username).run()
+        except Exception:
+            pass
+
+
 # ---------------------------------------------------------------------------
 # Mentor table helpers
 # ---------------------------------------------------------------------------
@@ -6060,6 +6086,7 @@ async def on_fetch(request, env) -> Response:
         if db:
             try:
                 await _ensure_leaderboard_schema(db)
+                await _backfill_referred_by(db)   # <-- ADD THIS
                 active_assignments = await _d1_get_active_assignments(db, org)
             except Exception as exc:
                 console.error(f"[MentorPool] Failed to fetch active assignments for homepage: {exc}")

--- a/src/worker.py
+++ b/src/worker.py
@@ -773,6 +773,7 @@ async def _load_mentors_from_d1(db) -> list:
     """
     try:
         await _ensure_leaderboard_schema(db)
+        await _backfill_referred_by(db)        # <-- ADD THIS LINE
         rows = await _d1_all(
             db,
             "SELECT github_username, name, specialties, max_mentees, active, timezone, referred_by, email, slack_username FROM mentors",
@@ -6086,7 +6087,6 @@ async def on_fetch(request, env) -> Response:
         if db:
             try:
                 await _ensure_leaderboard_schema(db)
-                await _backfill_referred_by(db)   # <-- ADD THIS
                 active_assignments = await _d1_get_active_assignments(db, org)
             except Exception as exc:
                 console.error(f"[MentorPool] Failed to fetch active assignments for homepage: {exc}")

--- a/src/worker.py
+++ b/src/worker.py
@@ -817,7 +817,7 @@ async def _load_mentors_from_d1(db) -> list:
     """
     try:
         await _ensure_leaderboard_schema(db)
-        await _backfill_referred_by(db)        # <-- ADD THIS LINE
+        await _backfill_referred_by(db)      
         rows = await _d1_all(
             db,
             "SELECT github_username, name, title, bio, specialties, max_mentees, active, timezone, referred_by, email, slack_username, total_prs FROM mentors",


### PR DESCRIPTION
Add _backfill_referred_by() function that idempotently updates the referred_by column for known mentor referral pairs where the value is currently NULL or empty.

- Runs automatically on every worker startup via on_fetch()
- Safe to call repeatedly (only patches NULL/empty rows)
- Covers 5 known mentor–referrer pairs from issue #52

Closes: #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically backfilled missing mentor referral data so mentor listings (including the homepage) now display complete and consistent "referred by" information; the update runs during mentor data load to ensure displayed records reflect the recovered referral values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->